### PR TITLE
Update request url on heroku landing page

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -17,7 +17,7 @@ IdP-initiated flow
 <p>Because it is initiated from the SP, you will need to make a request to:</p>
 
 <pre>
-  https://supersimplsamlidp.herokuapp.com/saml/auth
+  https://supersimplesamlidp.herokuapp.com/saml/auth
 </pre>
 
 You will also need to use the certificate fingerprint that supersimplesamlidp uses:


### PR DESCRIPTION
The auth link was missing the "e" in "supersimplesamlidp".